### PR TITLE
[ Bug ] - 의존성 보안 취약점 Close #68

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,4 +1,16 @@
 {
-  "lowestSeverity": "high", // 이 심각도 이상이면 실패 처리 (처음엔 high 권장)
-  "report": true // 리포트 출력 (CI 로그에서 보려고 true)
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  
+  // 예외 목록
+  // - 2025.08.25 기준, 예외 패키지 목록은 존재하지 않지만, 나중에 추가하기 위해 빈 배열로 작성
+  "allowlist": [
+
+  ],
+  
+  "high": true,               // 의존성 보안 취약점 심각도 종류 (high 이상 심각도 발견 시 빌드 실패)
+  "output-format": "text",    // 보고서 출력 형식 (기본값으로 설정했지만 명시적으로 작성)
+  "report-type": "summary",   // 보고서 요약 수준
+  "package-manager": "yarn",  // 패키지 매니저 Yarn으로 강제 지정
+  "skip-dev": false,          // 개발 의존성 보안 취약점 제외 여부 (기본값으로 설정했지만 명시적으로 작성)
+  "pass-enoaudit": false      // 감사 수행 불가(ENOAUDIT) 시 통과 처리 여부 (기본값으로 설정했지만 명시적으로 작성)
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #68 

### ✨ 작업 내용

기존 audit-ci.jsonc는 현재 audit-ci.jsonc@7 최신 버전이 아닌 과거 버전으로 구성이 되어있다 보니 제대로 된 의존성 보안 취약점을 탐지할 수 없는 오류를 확인했습니다. 이로 인해, 의존성 보안 취약점 환경 설정 파일내의 구성 옵션을 최신 버전으로 수정했습니다.